### PR TITLE
Detect clang and update lexer for gperf 3.1

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -1,12 +1,18 @@
-MRuby::Build.new do |conf|
-  # load specific toolchain settings
-
-  # Gets set by the VS command prompts.
+def detect_toolchain
   if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
+    :visualcpp
   else
-    toolchain :gcc
+    cc = ENV['CC'] || 'cc'
+    if `#{cc} --version 2>&1` =~ /clang/i
+      :clang
+    else
+      :gcc
+    end
   end
+end
+
+MRuby::Build.new do |conf|
+  toolchain detect_toolchain
 
   enable_debug
 
@@ -85,14 +91,7 @@ MRuby::Build.new do |conf|
 end
 
 MRuby::Build.new('host-debug') do |conf|
-  # load specific toolchain settings
-
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :gcc
-  end
+  toolchain detect_toolchain
 
   enable_debug
 
@@ -110,12 +109,7 @@ MRuby::Build.new('host-debug') do |conf|
 end
 
 MRuby::Build.new('test') do |conf|
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :gcc
-  end
+  toolchain detect_toolchain
 
   enable_debug
   conf.enable_bintest

--- a/mrbgems/mruby-compiler/core/keywords
+++ b/mrbgems/mruby-compiler/core/keywords
@@ -1,7 +1,7 @@
 %{
 struct kwtable {const char *name; int id[2]; enum mrb_lex_state_enum state;};
-const struct kwtable *mrb_reserved_word(const char *, unsigned int);
-static const struct kwtable *reserved_word(const char *, unsigned int);
+const struct kwtable *mrb_reserved_word(const char *, size_t);
+static const struct kwtable *reserved_word(const char *, size_t);
 #define mrb_reserved_word(str, len) reserved_word(str, len)
 %}
 

--- a/mrbgems/mruby-compiler/core/lex.def
+++ b/mrbgems/mruby-compiler/core/lex.def
@@ -31,8 +31,8 @@
 #line 1 "/home/matz/work/mruby/mrbgems/mruby-compiler/core/keywords"
 
 struct kwtable {const char *name; int id[2]; enum mrb_lex_state_enum state;};
-const struct kwtable *mrb_reserved_word(const char *, unsigned int);
-static const struct kwtable *reserved_word(const char *, unsigned int);
+const struct kwtable *mrb_reserved_word(const char *, size_t);
+static const struct kwtable *reserved_word(const char *, size_t);
 #define mrb_reserved_word(str, len) reserved_word(str, len)
 #line 8 "/home/matz/work/mruby/mrbgems/mruby-compiler/core/keywords"
 struct kwtable;
@@ -52,7 +52,7 @@ inline
 #endif
 #endif
 static unsigned int
-hash (register const char *str, register unsigned int len)
+hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
@@ -105,7 +105,7 @@ __attribute__ ((__gnu_inline__))
 #endif
 #endif
 const struct kwtable *
-mrb_reserved_word (register const char *str, register unsigned int len)
+mrb_reserved_word (register const char *str, register size_t len)
 {
   static const struct kwtable wordlist[] =
     {

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -24,7 +24,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
   conf.linker do |linker|
     linker.command = ENV['LD'] || 'gcc'
     linker.flags = [ENV['LDFLAGS'] || %w()]
-    linker.libraries = %w(m)
+    linker.libraries = RUBY_PLATFORM =~ /darwin/ ? %w() : %w(m)
     linker.library_paths = []
     linker.option_library = '-l%s'
     linker.option_library_path = '-L%s'


### PR DESCRIPTION
This would always default to `gcc`. Allow for it to determine if clang is `CC` and choose the correct toolchain file.