### PR TITLE
Detect clang and update lexer for gperf 3.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,15 +35,15 @@ load "#{MRUBY_ROOT}/tasks/gitlab.rake"
 task :default => :all
 
 bin_path = ENV['INSTALL_DIR'] || "#{MRUBY_ROOT}/bin"
-FileUtils.mkdir_p bin_path, { :verbose => $verbose }
+FileUtils.mkdir_p bin_path, verbose: $verbose
 
 depfiles = MRuby.targets['host'].bins.map do |bin|
   install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
   source_path = MRuby.targets['host'].exefile("#{MRuby.targets['host'].build_dir}/bin/#{bin}")
 
   file install_path => source_path do |t|
-    FileUtils.rm_f t.name, { :verbose => $verbose }
-    FileUtils.cp t.prerequisites.first, t.name, { :verbose => $verbose }
+    FileUtils.rm_f t.name, verbose: $verbose
+    FileUtils.cp t.prerequisites.first, t.name, verbose: $verbose
   end
 
   install_path
@@ -76,8 +76,8 @@ MRuby.each_target do |target|
         install_path = MRuby.targets['host'].exefile("#{bin_path}/#{bin}")
 
         file install_path => exec do |t|
-          FileUtils.rm_f t.name, { :verbose => $verbose }
-          FileUtils.cp t.prerequisites.first, t.name, { :verbose => $verbose }
+          FileUtils.rm_f t.name, verbose: $verbose
+          FileUtils.cp t.prerequisites.first, t.name, verbose: $verbose
         end
         depfiles += [ install_path ]
       elsif target == MRuby.targets['host-debug']
@@ -85,8 +85,8 @@ MRuby.each_target do |target|
           install_path = MRuby.targets['host-debug'].exefile("#{bin_path}/#{bin}")
 
           file install_path => exec do |t|
-            FileUtils.rm_f t.name, { :verbose => $verbose }
-            FileUtils.cp t.prerequisites.first, t.name, { :verbose => $verbose }
+            FileUtils.rm_f t.name, verbose: $verbose
+            FileUtils.cp t.prerequisites.first, t.name, verbose: $verbose
           end
           depfiles += [ install_path ]
         end
@@ -125,16 +125,16 @@ end
 desc "clean all built and in-repo installed artifacts"
 task :clean do
   MRuby.each_target do |t|
-    FileUtils.rm_rf t.build_dir, { :verbose => $verbose }
+    FileUtils.rm_rf t.build_dir, verbose: $verbose
   end
-  FileUtils.rm_f depfiles, { :verbose => $verbose }
+  FileUtils.rm_f depfiles, verbose: $verbose
   puts "Cleaned up target build folder"
 end
 
 desc "clean everything!"
 task :deep_clean => ["clean"] do
   MRuby.each_target do |t|
-    FileUtils.rm_rf t.gem_clone_dir, { :verbose => $verbose }
+    FileUtils.rm_rf t.gem_clone_dir, verbose: $verbose
   end
   puts "Cleaned up mrbgems build folder"
 end

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,12 +1,18 @@
-MRuby::Build.new do |conf|
-  # load specific toolchain settings
-
-  # Gets set by the VS command prompts.
+def detect_toolchain
   if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
+    :visualcpp
   else
-    toolchain :gcc
+    cc = ENV['CC'] || 'cc'
+    if `#{cc} --version 2>&1` =~ /clang/i
+      :clang
+    else
+      :gcc
+    end
   end
+end
+
+MRuby::Build.new do |conf|
+  toolchain detect_toolchain
 
   enable_debug
 
@@ -85,14 +91,7 @@ MRuby::Build.new do |conf|
 end
 
 MRuby::Build.new('host-debug') do |conf|
-  # load specific toolchain settings
-
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :gcc
-  end
+  toolchain detect_toolchain
 
   enable_debug
 
@@ -110,12 +109,7 @@ MRuby::Build.new('host-debug') do |conf|
 end
 
 MRuby::Build.new('test') do |conf|
-  # Gets set by the VS command prompts.
-  if ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
-    toolchain :visualcpp
-  else
-    toolchain :gcc
-  end
+  toolchain detect_toolchain
 
   enable_debug
   conf.enable_bintest

--- a/mrbgems/mruby-compiler/core/keywords
+++ b/mrbgems/mruby-compiler/core/keywords
@@ -1,7 +1,7 @@
 %{
 struct kwtable {const char *name; int id[2]; enum mrb_lex_state_enum state;};
-const struct kwtable *mrb_reserved_word(const char *, unsigned int);
-static const struct kwtable *reserved_word(const char *, unsigned int);
+const struct kwtable *mrb_reserved_word(const char *, size_t);
+static const struct kwtable *reserved_word(const char *, size_t);
 #define mrb_reserved_word(str, len) reserved_word(str, len)
 %}
 

--- a/mrbgems/mruby-compiler/core/lex.def
+++ b/mrbgems/mruby-compiler/core/lex.def
@@ -31,8 +31,8 @@
 #line 1 "/home/matz/work/mruby/mrbgems/mruby-compiler/core/keywords"
 
 struct kwtable {const char *name; int id[2]; enum mrb_lex_state_enum state;};
-const struct kwtable *mrb_reserved_word(const char *, unsigned int);
-static const struct kwtable *reserved_word(const char *, unsigned int);
+const struct kwtable *mrb_reserved_word(const char *, size_t);
+static const struct kwtable *reserved_word(const char *, size_t);
 #define mrb_reserved_word(str, len) reserved_word(str, len)
 #line 8 "/home/matz/work/mruby/mrbgems/mruby-compiler/core/keywords"
 struct kwtable;
@@ -52,7 +52,7 @@ inline
 #endif
 #endif
 static unsigned int
-hash (register const char *str, register unsigned int len)
+hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
@@ -105,7 +105,7 @@ __attribute__ ((__gnu_inline__))
 #endif
 #endif
 const struct kwtable *
-mrb_reserved_word (register const char *str, register unsigned int len)
+mrb_reserved_word (register const char *str, register size_t len)
 {
   static const struct kwtable wordlist[] =
     {

--- a/tasks/toolchains/gcc.rake
+++ b/tasks/toolchains/gcc.rake
@@ -24,7 +24,7 @@ MRuby::Toolchain.new(:gcc) do |conf, _params|
   conf.linker do |linker|
     linker.command = ENV['LD'] || 'gcc'
     linker.flags = [ENV['LDFLAGS'] || %w()]
-    linker.libraries = %w(m)
+    linker.libraries = RUBY_PLATFORM =~ /darwin/ ? %w() : %w(m)
     linker.library_paths = []
     linker.option_library = '-l%s'
     linker.option_library_path = '-L%s'


### PR DESCRIPTION
This is meant to align with changes in NixOS 25.11, in particular gperf 3.0 was removed and gperf 3.1 is the only version available. In addition, there were changes to the darwin stdenv so the existing gcc compatibility no longer works.